### PR TITLE
Acrescentando IRPF 2023

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 version: '3'
 
 services:
+  irpf-2023:
+    build:
+      context: .
+      dockerfile: irpf-2023.dockerfile
+    environment:
+      - DISPLAY=$DISPLAY
+      - _JAVA_OPTIONS='-Dawt.useSystemAAFontSettings=on'
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - $HOME:/home/irpf
   irpf-2022:
     build:
       context: .

--- a/irpf-2023.dockerfile
+++ b/irpf-2023.dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:11
+
+RUN chmod 1777 /tmp \
+    && apt-get update \
+    && apt-get install -o APT::Immediate-Configure=0 -y --no-install-recommends libgtk2.0-0 libcanberra-gtk-module libxext-dev libxrender-dev libxtst-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://downloadirpf.receita.fazenda.gov.br/irpf/2023/irpf/arquivos/IRPF2023-1.1.zip -O IRPF2023.zip
+RUN unzip IRPF2023.zip -d /opt/
+
+RUN groupadd --gid 1000 irpf && \
+    useradd --gid 1000 --uid 1000 --create-home --shell /bin/bash irpf
+
+USER irpf
+
+ENV TZ=America/Sao_Paulo
+
+CMD ["java", "-Xms128M", "-Xmx512M", "-jar", "/opt/IRPF2023/irpf.jar"]


### PR DESCRIPTION
Oi! Adicionando IRPF desse ano.

Fiz duas modificações no padrão dos arquivos do ano anterior:
- `_JAVA_OPTIONS='-Dawt.useSystemAAFontSettings=on'` ajudou a melhorar as fontes das letras aqui.
- `chmod 1777 /tmp` foi necessário para o apt funcionar na imagem Debian, não sei por quê.